### PR TITLE
hotfix: korean regular-expression fix

### DIFF
--- a/src/main/java/com/jh/openapi/randomword/domain/entity/type/LanguageType.java
+++ b/src/main/java/com/jh/openapi/randomword/domain/entity/type/LanguageType.java
@@ -6,7 +6,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum LanguageType {
-    KOR,
-    ENG,
+    KOR("한글"),
+    ENG("영어"),
     ;
+
+    private final String description;
 }

--- a/src/main/java/com/jh/openapi/randomword/validation/validator/LanguageValidator.java
+++ b/src/main/java/com/jh/openapi/randomword/validation/validator/LanguageValidator.java
@@ -10,7 +10,7 @@ import java.util.regex.Pattern;
 
 public class LanguageValidator implements ConstraintValidator<Language, String> {
     private static final Pattern ENG_PATTERN = Pattern.compile("^[a-zA-Z]+$");
-    private static final Pattern KOR_PATTERN = Pattern.compile("^[가-힇,\\s]+$");
+    private static final Pattern KOR_PATTERN = Pattern.compile("^[가-힣,\\s]+$");
     private LanguageType languageType;
 
     @Override

--- a/src/main/java/com/jh/openapi/randomword/validation/validator/LanguageValidator.java
+++ b/src/main/java/com/jh/openapi/randomword/validation/validator/LanguageValidator.java
@@ -2,6 +2,7 @@ package com.jh.openapi.randomword.validation.validator;
 
 import com.jh.openapi.randomword.domain.entity.type.LanguageType;
 import com.jh.openapi.randomword.validation.annotation.Language;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.validation.ConstraintValidator;
@@ -29,6 +30,14 @@ public class LanguageValidator implements ConstraintValidator<Language, String> 
             case KOR -> KOR_PATTERN;
         };
 
-        return pattern.matcher(value).matches();
+        boolean matches = pattern.matcher(value).matches();
+
+        if (BooleanUtils.isFalse(matches)) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(languageType.getDescription() + "로 입력 되어야 합니다.")
+                    .addConstraintViolation();
+        }
+
+        return matches;
     }
 }


### PR DESCRIPTION
### Overview
---
> Korean regular-expression error fix (`[가-힇,\\s]+$` -> `[가-힣,\\s]+$`) and request param validator static message is convert to dynamic message

### Jobs
---
- Fix Korean regular-expression
- Convert request validator message to dynamic message